### PR TITLE
Pass active record column object, instead of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 - 2019-11-06
+### Fixed
+- Passing arguments to `rake pii_safe_schema:generate_migrations` actually works
+
 ## 1.3.0 - 2019-11-04
 ### Added
 - Can pass explicitly annotate PII columns from the command line as arguments when using `rake pii_safe_schema:generate_migrations`.

--- a/lib/pii_safe_schema/pii_column.rb
+++ b/lib/pii_safe_schema/pii_column.rb
@@ -15,11 +15,13 @@ module PiiSafeSchema
       end
 
       def from_column_name(table:, column:, suggestion:)
-        unless connection.columns(table.to_s).find { |c| c.name == column.to_s }
+        activerecord_column = connection.columns(table.to_s).find { |c| c.name == column.to_s }
+
+        unless activerecord_column
           raise InvalidColumnError, "column \"#{column}\" does not exist for table \"#{table}\""
         end
 
-        new(table: table, column: column, suggestion: suggestion)
+        new(table: table, column: activerecord_column, suggestion: suggestion)
       end
 
       private

--- a/lib/pii_safe_schema/version.rb
+++ b/lib/pii_safe_schema/version.rb
@@ -1,3 +1,3 @@
 module PiiSafeSchema
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end

--- a/lib/tasks/pii_safe_schema.rake
+++ b/lib/tasks/pii_safe_schema.rake
@@ -9,6 +9,7 @@ namespace :pii_safe_schema do
       PiiSafeSchema.generate_migrations(additional_columns)
     end
 
+    exit(0) # forces rake to stop after this and not assume args are tasks
   rescue ActiveRecord::StatementInvalid, PiiSafeSchema::InvalidColumnError => e
     raise e if e.class == ActiveRecord::StatementInvalid && e.cause.class != PG::UndefinedTable
 
@@ -19,7 +20,7 @@ namespace :pii_safe_schema do
 
       Please create the table & columns first, running their migrations, before attempting to use the pii_safe_schema generator.
     HEREDOC
-  ensure
-    exit(0) # forces rake to stop after this and not assume args are tasks
+
+    exit(1) # forces rake to stop after this and not assume args are tasks
   end
 end

--- a/spec/pii_safe_schema/pii_column_spec.rb
+++ b/spec/pii_safe_schema/pii_column_spec.rb
@@ -115,7 +115,7 @@ describe PiiSafeSchema::PiiColumn do
     it do
       expect(from_column_name).to have_attributes(
         table: :users,
-        column: be_an_instance_of(ActiveRecord::ConnectionAdapters::Column),
+        column: be_a_kind_of(ActiveRecord::ConnectionAdapters::Column),
         suggestion: suggestion,
       )
     end

--- a/spec/pii_safe_schema/pii_column_spec.rb
+++ b/spec/pii_safe_schema/pii_column_spec.rb
@@ -115,9 +115,13 @@ describe PiiSafeSchema::PiiColumn do
     it do
       expect(from_column_name).to have_attributes(
         table: :users,
-        column: 'landline',
+        column: be_an_instance_of(ActiveRecord::ConnectionAdapters::Column),
         suggestion: suggestion,
       )
+    end
+
+    it 'finds the correct activerecord column' do
+      expect(from_column_name.column).to have_attributes(name: 'landline')
     end
 
     it { expect(from_column_name).to be_an_instance_of(described_class) }


### PR DESCRIPTION

#### Why <!-- A short description of why this change is required -->

Made an oversight in #20. Passed a string of a column name and not the active record object and, due to `ensure; exit` the error was swallowed during use.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

* Pass the appropriate object to make it all work
* Use `exit` in a way that doesn't swallow all runtime exceptions

#### Next steps

Consider adding integration tests that generate a dummy app, and annotate all types as expected.

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
