### PR TITLE
ci: update or add stale workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @wealthsimple/platform-security
+.github/workflows/* @wealthsimple/developer-tools @wealthsimple/platform-security

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           days-before-stale: 30
-          days-before-close: 60
+          days-before-close: 30
           stale-pr-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.1 - 2022-04-14
+### Changed
+- Fixing lint issues
+
 ## 1.4.0 - 2021-12-31
 ### Changed
 - Add Ruby 3.0.x support

--- a/lib/pii_safe_schema/migration_generator.rb
+++ b/lib/pii_safe_schema/migration_generator.rb
@@ -9,14 +9,13 @@ module PiiSafeSchema
 
       private
 
-      # rubocop:disable Metrics/AbcSize
       def generate_migration_for(table, columns)
         generator = ActiveRecord::Generators::MigrationGenerator.new(
           ["change_comments_in_#{table}"],
         )
         generated_lines = generate_migration_lines(table, columns)
         migration_file = generator.create_migration_file
-        file_lines = File.open(migration_file, 'r').read.split("\n")
+        file_lines = File.read(migration_file).split("\n")
         change_line = file_lines.find_index { |i| /def change/.match(i) }
         new_contents = file_lines[0..change_line] + generated_lines + file_lines[change_line + 1..]
 
@@ -26,7 +25,6 @@ module PiiSafeSchema
         end
         migration_file
       end
-      # rubocop:enable Metrics/AbcSize
 
       def generate_migration_lines(table, columns)
         migration_lines = columns.map do |c|

--- a/lib/pii_safe_schema/version.rb
+++ b/lib/pii_safe_schema/version.rb
@@ -1,3 +1,3 @@
 module PiiSafeSchema
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.4.1'.freeze
 end


### PR DESCRIPTION
### Why
We want to reduce the default amount of time it takes to close PRs that have been marked as `stale`, from 60 days to 30 days.

The stale workflow uses GitHub Actions to automatically mark PRs as stale and eventually close them if there is no detected activity. This workflow excludes any dependency or security PRs.

For more information about the stale GitHub Action see: https://github.com/actions/stale

### What changed
* Add @wealthsimple/developer-tools as a CODEOWNER for all GitHub Actions workflows (if applicable)
* If this repo has an existing `stale.yml` workflow, reduce the `days-before-close` from 60 to 30 (if applicable)
* If this repo _does not_ have a `stale.yml' workflow, add one!

:warning: **This PR was opened automatically!** :warning: Please reach out in #developer-tools on Slack if you have any questions!