### PR TITLE
chore(ci): remove PR trigger from default job

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,8 +6,6 @@ name: Default
 # pushes to the branch will provide PR information of any open PRs.
 on:
   push:
-  pull_request:
-    types: [opened, reopened]
 
 concurrency:
   group: default-${{ github.ref }}


### PR DESCRIPTION
### Why
The PR triggers are only necessary if we want to use the Sonarqube Quality Gate as a required check. It uses up a lot of extra Github Actions minutes because it runs the default workflow an extra time for each pull request created. It also causes some confusion because the Jobs show up twice under the checks section. We want to default to not running this workflow when PRs are open.

### What
- Removed PR trigger from default workflow

### NOTE
If you want to keep this trigger for any reason, then please comment and close this PR. Otherwise we will be merging it.
