### PR TITLE
chore: update GitHub Actions to most recent versions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,7 +20,7 @@ jobs:
         ruby-version: [2.7.5, 3.0.3]
     steps:
       # Need to fetch all refs, so we can check if the version has been bumped
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     needs:
       - preflight_check
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v8
         with:
           days-before-stale: 30
           days-before-close: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.3 - 2023-05-11
+### Changed
+- Updated workflows to use most recent Actions
+
 ## 1.4.2 - 2023-02-23
 ### Changed
 - Remove references to toolbox-script in workflows

--- a/lib/pii_safe_schema/version.rb
+++ b/lib/pii_safe_schema/version.rb
@@ -1,3 +1,3 @@
 module PiiSafeSchema
-  VERSION = '1.4.2'.freeze
+  VERSION = '1.4.3'.freeze
 end


### PR DESCRIPTION
### Why
GitHub is deprecating the use of Node 12 in GitHub Actions. Many of the older versions of Actions are using Node 12. You will likely see a number of warning messages on your workflow runs about Node 12 being deprecated. Upgrading to the most recent versions of GitHub Actions will fix these warnings and prevent workflows from failing in the future when GitHub removes Node 12 completely.

### What
Replaced the most commonly used Actions with their most recent versions. Note that this won't update all Actions so you might want to review your workflows to check if they are using older versions of other Actions.

Note: This will not affect any production code so it should be safe to merge.

Please reach out in #developer-tools if you have any questions.
