### PR TITLE
chore: add changelog link to gemspec

### DIFF
--- a/pii_safe_schema.gemspec
+++ b/pii_safe_schema.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
 
   s.summary = 'Schema migration tool for checking and adding comments on PII columns.'
   s.homepage = 'https://github.com/wealthsimple/pii_safe_schema'
+  s.metadata['changelog_uri'] = 'https://github.com/wealthsimple/pii_safe_schema/blob/master/CHANGELOG.md'
   s.license = "MIT"
   s.required_ruby_version = Gem::Requirement.new(">= 2.6")
 


### PR DESCRIPTION
### Why

This will make it easier to keep dependencies up to date!

Depfu and Dependabot use the `changelog_uri` field to add a link to the changelog for this gem in dependency update PRs.

Related ticket: https://wealthsimple.atlassian.net/browse/BEPLAT-130

### What Changed

* Add `metadata.changelog_uri` field to the gemspec

⚠ **This PR was opened automatically** ⚠ please reach out to #developer-tools on Slack if you have any questions!
