### PR TITLE
chore: add changelog link to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.4 - 2023-07-26
+### Added
+- chore: add changelog link to gemspec
+
 ## 1.4.3 - 2023-05-11
 ### Changed
 - Updated workflows to use most recent Actions

--- a/lib/pii_safe_schema/version.rb
+++ b/lib/pii_safe_schema/version.rb
@@ -1,3 +1,3 @@
 module PiiSafeSchema
-  VERSION = '1.4.3'.freeze
+  VERSION = '1.4.4'.freeze
 end

--- a/pii_safe_schema.gemspec
+++ b/pii_safe_schema.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
 
   s.summary = 'Schema migration tool for checking and adding comments on PII columns.'
   s.homepage = 'https://github.com/wealthsimple/pii_safe_schema'
+  s.metadata['changelog_uri'] = 'https://github.com/wealthsimple/pii_safe_schema/blob/master/CHANGELOG.md'
   s.license = "MIT"
   s.required_ruby_version = Gem::Requirement.new(">= 2.6")
 


### PR DESCRIPTION
### Why

This will make it easier to keep dependencies up to date!

Depfu and Dependabot use the `changelog_uri` field to add a link to the changelog for this gem in dependency update PRs.

Related ticket: https://wealthsimple.atlassian.net/browse/BEPLAT-130

### What Changed

* Add `metadata.changelog_uri` field to the gemspec

⚠ **This PR was opened automatically** ⚠ please reach out to #developer-tools on Slack if you have any questions!
