### PR TITLE
chore: update ownerhsip to appsec-posture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @wealthsimple/platform-security
-.github/workflows/* @wealthsimple/developer-tools @wealthsimple/platform-security
+* @wealthsimple/appsec-posture
+.github/workflows/* @wealthsimple/developer-tools @wealthsimple/appsec-posture

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 Schema migration tool for checking and adding comments on *Personally Identifiable Information* (PII) columns in Rails.
 
+Maintained by the [Application Security & Posture Management Team](https://github.com/orgs/wealthsimple/teams/appsec-posture).
+You can find us on slack at [#appsec-posture](https://wealthsimple.slack.com/archives/C05AZ5R23PH)
+
 Specifically, this gem serves a few functions:
 
 * Warning you when you might be missing an annotation on a column


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

Appsec-posture is inheriting services from platform-security


#### What changed <!-- Summary of changes when modifying hundreds of lines -->

- codeowners
- readme

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
